### PR TITLE
Remove homepage tagline copy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,9 +17,6 @@ const site = Astro.site?.toString().replace(/\/$/, '') ?? '';
 
 <Base canonical={`${site}/`}>
   <h1 class="home-h1">Pick a random episode of your favorite TV show</h1>
-  <p class="home-tagline">
-    Spin the tape and let episode.lol surprise you with a random episode from any television series.
-  </p>
 
   <Home client:load />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -471,9 +471,6 @@ a.cast-card:hover .actor { color: var(--cyan); }
 /* ---------- server-rendered SEO content (series header, episode index, home) ---------- */
 .home-h1 { font-family: var(--font-chan); font-size: clamp(20px, 4.6vw, 32px); line-height: 1.15;
   color: var(--cyan); text-shadow: 1.5px 1.5px 0 var(--magenta); text-align: center; margin: 4px 0 6px; }
-.home-tagline { font-family: var(--font-osd); font-size: 19px; color: var(--gold); opacity: .85;
-  text-align: center; max-width: 640px; margin: 0 auto 6px; }
-
 .series-head { text-align: center; margin-bottom: 6px; }
 .series-head h1 { font-family: var(--font-chan); font-size: clamp(20px, 4.4vw, 30px); margin: 4px 0;
   color: var(--cyan); text-shadow: 1.5px 1.5px 0 var(--magenta); }


### PR DESCRIPTION
## Summary
- Removes the "Spin the tape and let episode.lol surprise you..." tagline paragraph from the homepage, under the h1
- Removes the now-unused `.home-tagline` CSS rule

## Test plan
- [x] `npm run build` succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_013ARx6gZ1DjbS4aAhRRP13r)_